### PR TITLE
Serve ui from local

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ app.listen(8080);
 * `uiEndpoint`:(default: /openapi.html) - The endpoint for serving Openapi UI
 * `validateResponse`:(default: false) - Validate response against Openapi schemas
 * `validatePaths`:(default ['/']) - Only endpoints starting with the values specified here will be validated
+* `swaggerUi`: (default use swagger-ui-dist from [unpkg](https://unpkg.com/)) - [swaggerUiAssetPath](https://www.npmjs.com/package/swagger-ui-dist) needed for loading the swagger-ui

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,10 @@ export interface Config {
    * default: ['/']
    */
   validatePaths: string[];
+  /**
+   * Optional base path to swagger ui bundle
+   */
+  swaggerUi: string;
 }
 
 export function validateConfig(cfg: Partial<Config>): Config {
@@ -34,5 +38,6 @@ export function validateConfig(cfg: Partial<Config>): Config {
     uiEndpoint: cfg.uiEndpoint || '/openapi.html',
     validateResponse: cfg.validateResponse || false,
     validatePaths: cfg.validatePaths || ['/'],
+    swaggerUi: cfg.swaggerUi || '//unpkg.com/swagger-ui-dist@3'
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export function oas(cfg: Partial<Config>): koa.Middleware {
       ctx.body = openapiUI({
         title: doc.info ? doc.info.title : 'openapi UI',
         url: config.endpoint,
+        swaggerUi: config.swaggerUi
       });
       return;
     }

--- a/src/openapi-ui.ts
+++ b/src/openapi-ui.ts
@@ -1,6 +1,7 @@
 export interface OpenapiUIConfig {
   title?: string;
   url: string;
+  swaggerUi: string;
 }
 
 export function openapiUI(cfg: OpenapiUIConfig): string { return `
@@ -8,7 +9,7 @@ export function openapiUI(cfg: OpenapiUIConfig): string { return `
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <base href="//unpkg.com/swagger-ui-dist@3/">
+  <base href="${cfg.swaggerUi}">
   <title>${cfg.title || 'Swagger UI'}</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
   <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >


### PR DESCRIPTION
I would much prefer to serve the swagger ui from my own machine instead of over http from unpkg.

This pr provides a `swaggerUi` configuration setting for specifying the base url to the swagger ui dist files (defaulting to unpkg)