### PR TITLE
fix: store coerced values in a new field within Koa Context.

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -66,7 +66,7 @@ describe('Koa Oas3', () => {
     };
     const next = jest.fn();
     await mw(ctx, next);
-    expect(ctx.query.limit).toEqual(10);
+    expect(ctx.oas.request.query.limit).toBe(10);
   });
 
   test('It should throw ValidationError if validation failed', () => {


### PR DESCRIPTION
It looks like fields like ctx.query and ctx.request.query are special and cannot be easily overriden, so I'm proposing to store the coerced values generated by the OpenAPI 3 validator to a new oas field in the Context.