### PR TITLE
allow object as the open api spec instead of reading it from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ app.listen(8080);
 ### options:
 
 * `file` - The absolute path to your Openapi file
+* `spec` - javascript object defining the api, either this or `file` must be given.
 * `endpoint`(default: /openapi.json) - The endpoint for serving Openapi JSON
 * `uiEndpoint`:(default: /openapi.html) - The endpoint for serving Openapi UI
 * `validateResponse`:(default: false) - Validate response against Openapi schemas

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,11 @@ export interface Config {
   /**
    * Absolute path to Openapi Document
    */
-  file: string;
+  file?: string;
+  /**
+   * Openapi document as a javascript object
+   */
+  spec?: object,
   /**
    * Endpoint that serves raw Openapi Document in JSON
    * default: /openapi.json
@@ -46,11 +50,12 @@ function defaultErrorHandler(err: Error, ctx: Context) {
 }
 
 export function validateConfig(cfg: Partial<Config>): Config {
-  if (!cfg.file) {
-    throw new Error('You must configure a Openapi File');
+  if (!cfg.file && !cfg.spec) {
+    throw new Error('You must configure a Openapi File or a OpenAPIObject object');
   }
   return {
     file: cfg.file,
+    spec: cfg.spec,
     endpoint: cfg.endpoint || '/openapi.json',
     uiEndpoint: cfg.uiEndpoint || '/openapi.html',
     validateResponse: cfg.validateResponse || false,


### PR DESCRIPTION
Defining the api as a a (OpenAPIObject)[https://github.com/metadevpro/openapi3-ts/blob/master/src/model/OpenApi.ts#L18] is quite handy as then we get ide support with no cost.

To make using this scheme more straightforward this PR makes koa-oas3 accept a javascript object instead of a file as the openapi specification so we do not have to serialize the js object to a file in between.