### PR TITLE
use href instead of just the orgin when instantiating SwaggerUIBundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "koa-oas3",
-  "version": "0.13.1",
+  "name": "koa-oas3-jfmeachum",
+  "version": "0.13.4",
   "main": "lib/index.js",
   "types": "lib/index.d.js",
   "author": "<tli@atlassian.com>",

--- a/src/openapi-ui.ts
+++ b/src/openapi-ui.ts
@@ -81,7 +81,7 @@ window.onload = function() {
 
   // Build a system
   const ui = SwaggerUIBundle({
-    url: window.location.origin + "${cfg.url}",
+    url: window.location.href.replace(/\\/+$/, '') + "${cfg.url}",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
Resolves issue when accessing the UI through a reverse proxy where the UI would not be able to find the location of the requisite OAS schema.