### PR TITLE
should NOT use any body parser if schema is empty

### DIFF
--- a/__tests__/fixtures/pet-store.json
+++ b/__tests__/fixtures/pet-store.json
@@ -109,6 +109,28 @@
             }
           }
         }
+      },
+      "put": {
+        "summary": "Create an empty pet",
+        "operationId": "createEmptyPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/pets/{petId}": {

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -216,6 +216,40 @@ describe('Koa Oas3', () => {
     expect(bodyHandler).not.toHaveBeenCalled();
   });
 
+  test('It should not pick any body handler if the body schema is empty', async () => {
+    const ctx = createContext({
+      url: '/pets/123',
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      },
+      method: 'PUT',
+      body: {
+        id: 1,
+        tag: 'tag',
+        name: 'name'
+      }
+    });
+    const next = jest.fn();
+    const bodyHandler = jest.fn().mockImplementation(bodyParser({
+      extendTypes: {
+        json: ['application/json']
+      },
+      enableTypes: ['json']
+    }));
+    const mw = oas({
+      file: path.resolve('./__tests__/fixtures/pet-store.json'),
+      endpoint: '/openapi',
+      uiEndpoint: '/openapi.html',
+      validatePaths: ['/pets'],
+      requestBodyHandler: {
+        'application/json': bodyHandler,
+      }
+    });
+    await expect(mw(ctx, next)).resolves.toEqual(undefined);
+    expect(bodyHandler).not.toHaveBeenCalled();
+  });
+
   test('It should not pick any body handler if it is NOT defined in the config', async () => {
     const ctx = createContext({
       url: '/pets/123',

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ export function oas(cfg: Partial<Config>): koa.Middleware {
     const middlewares: Array<koa.Middleware> = [];
     const requestContentTypes = compiled.getDefinedRequestBodyContentType(ctx.path, ctx.request.method);
     const matchedContentType = ctx.request.is(requestContentTypes);
-    if (config.requestBodyHandler && matchedContentType && typeof matchedContentType === 'string') {
+    if (requestContentTypes.length && config.requestBodyHandler && matchedContentType && typeof matchedContentType === 'string') {
       // We need to find the most specific matched handler
       const parts = matchedContentType.split('/');
       if (config.requestBodyHandler[matchedContentType]) {


### PR DESCRIPTION
I was expecting the typeIs(req, []) would return nothing, but it actually return the content-type from the request directly.

/cc @lukiano @lucaslago 