### PR TITLE
Uses qs module to parse query-string

### DIFF
--- a/.changeset/light-snakes-tan.md
+++ b/.changeset/light-snakes-tan.md
@@ -1,0 +1,5 @@
+---
+"koa-oas3-jfmeachum": minor
+---
+
+Use qs module to parse query-string before validation

--- a/__tests__/fixtures/pet-store.json
+++ b/__tests__/fixtures/pet-store.json
@@ -22,6 +22,41 @@
         ],
         "parameters": [
           {
+            "name": "fields",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "name",
+                  "breed",
+                  "age",
+                  "weight"
+                ]
+              }
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string",
+                  "enum": [
+                    "red",
+                    "green",
+                    "black",
+                    "white"
+                  ]
+                }
+              }
+            }
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "How many items to return at one time (max 100)",
@@ -41,7 +76,12 @@
               "maxItems": 3,
               "items": {
                 "type": "string",
-                "enum": ["bichon", "chowchow", "jack russel", "labrador"]
+                "enum": [
+                  "bichon",
+                  "chowchow",
+                  "jack russel",
+                  "labrador"
+                ]
               }
             }
           }
@@ -86,7 +126,7 @@
         "requestBody": {
           "description": "The pet information",
           "content": {
-            "application/json":{
+            "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/Pet"
               }
@@ -194,7 +234,7 @@
         "requestBody": {
           "description": "The pet information",
           "content": {
-            "application/json":{
+            "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/Pet"
               }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "koa-bodyparser": "^4.2.1",
     "koa-compose": "^4.1.0",
     "oas-validator": "^3.3.1",
-    "oas3-chow-chow": "^0.17.0"
+    "oas3-chow-chow": "^0.17.0",
+    "qs": "^6.9.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.0.3",
@@ -40,6 +41,7 @@
     "@types/jsonfile": "^5.0.0",
     "@types/koa": "^2.0.49",
     "@types/koa-bodyparser": "^4.3.0",
+    "@types/qs": "^6.5.3",
     "babel-core": "^6.26.3",
     "babel-jest": "^24.9.0",
     "jest": "^24.9.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import * as yaml from 'js-yaml';
 import * as fs from 'fs';
 import * as oasValidator from 'oas-validator';
 import * as compose from 'koa-compose';
+import * as qs from 'qs';
 
 export { ChowError, RequestValidationError, ResponseValidationError };
 
@@ -39,7 +40,7 @@ export function oas(cfg: Partial<Config>): koa.Middleware {
       const validRequest = compiled.validateRequest(ctx.path, {
         method: ctx.request.method,
         header: ctx.request.header,
-        query: ctx.request.query,
+        query: qs.parse(ctx.request.querystring, { comma: true }),
         path: ctx.params,
         cookie: ctx.cookies,
         body: (ctx.request as RequestWithBody).body,


### PR DESCRIPTION
Koa's internal query parser does not deserialize deep objects
from the query-string, hence koa-oas3 does not enforce
the schema validation for these parameters.

Using qs module to parse the query-string before validation
addresses this limitation.