### PR TITLE
Allowing injection of query parsing options to the qs parser

### DIFF
--- a/.changeset/thirty-forks-love.md
+++ b/.changeset/thirty-forks-love.md
@@ -1,0 +1,7 @@
+---
+"koa-oas3": minor
+---
+
+Adds options for querystring parsing for validation.
+
+This allows individuals to specify options for how incoming query strings should be parsed (such as for array structures).  By default it maintains the existing option of parsing commas as a delimiter for entries in an array parameter. For more info on how to inject different options see README.md

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ app.listen(8080);
 * `validateResponse`:(default: false) - Validate response against Openapi schemas
 * `validatePaths`:(default ['/']) - Only endpoints starting with the values specified here will be validated
 * `swaggerUiBundleBasePath`: (default use swagger-ui-dist from [unpkg](https://unpkg.com/)) - [swaggerUiAssetPath](https://www.npmjs.com/package/swagger-ui-dist) needed for loading the swagger-ui
+* `qsParseOptions: { [key: string]: any}`: Optional - Options to be passed to the [query string](https://github.com/ljharb/qs) parse command. Default: `{ comma: true }`
 * `errorHandler: (error: Error, ctx: Context) => void,`: Optional - custom error hanlder.
 * `requestBodyHandler: { [key: string]: koa.Middleware }`: Optional - custom body handler. Defaults:
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,7 @@ export interface Config {
    * Optional options for sending to oas3-chow-chow/AJV
    */
   validationOptions?: Partial<ChowOptions>;
+  qsParseOptions?: qs.IParseOptions;
 }
 
 function defaultErrorHandler(err: Error, ctx: Context) {
@@ -82,6 +83,7 @@ export function validateConfig(cfg: Partial<Config>): Config {
     validatePaths: cfg.validatePaths || ['/'],
     swaggerUiBundleBasePath: cfg.swaggerUiBundleBasePath || '//unpkg.com/swagger-ui-dist@3/',
     errorHandler: cfg.errorHandler || defaultErrorHandler,
+    qsParseOptions: cfg.qsParseOptions || { comma: true },
     requestBodyHandler: cfg.requestBodyHandler || {
       'application/json': bodyParser({
         extendTypes: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export function oas(cfg: Partial<Config>): koa.Middleware {
       const validRequest = compiled.validateRequest(ctx.path, {
         method: ctx.request.method,
         header: ctx.request.header,
-        query: qs.parse(ctx.request.querystring, { comma: true }),
+        query: qs.parse(ctx.request.querystring, config.qsParseOptions),
         path: ctx.params,
         cookie: ctx.cookies,
         body: (ctx.request as RequestWithBody).body,


### PR DESCRIPTION
We've run into an issue where we have an endpoint for locations where we don't want to specify to the users that they MUST encode a comma as part of a location search.  The use of the `qs` query string handler is currently hard-coded to force commas to become arrays.  This PR would keep that behavior intact for everyone else but allow us and others with this need to change how the validator parses the incoming query strings.