### PR TITLE
add oasValidatorOptions for oas-validator

### DIFF
--- a/.changeset/two-spiders-film.md
+++ b/.changeset/two-spiders-film.md
@@ -1,0 +1,5 @@
+---
+"koa-oas3": minor
+---
+
+add oasValidatorOptions for oas-validator

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,11 @@ export interface Config {
    * Optional options for sending to oas3-chow-chow/AJV
    */
   validationOptions?: Partial<ChowOptions>;
+  /**
+   * Optional options for sending to oas-validator.
+   * https://github.com/Mermade/oas-kit/blob/main/docs/options.md
+   */
+  oasValidatorOptions?: object;
   qsParseOptions?: qs.IParseOptions;
 }
 
@@ -105,6 +110,7 @@ export function validateConfig(cfg: Partial<Config>): Config {
         enableTypes: ['form']
       })
     },
-    validationOptions: cfg.validationOptions
+    validationOptions: cfg.validationOptions,
+    oasValidatorOptions: cfg.oasValidatorOptions
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,7 +143,7 @@ async function compileOas(config: Config) {
   try {
     await oasValidator.validateInner(openApiObject, config.oasValidatorOptions || {});
   } catch (err) {
-    throw new Error('Invalid Openapi document');
+    throw new Error('Invalid Openapi document' + err.message);
   }
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ async function loadFromFile(file?: string): Promise<any> {
 async function compileOas(config: Config) {
   let openApiObject: any = config.spec || await loadFromFile(config.file);
   try {
-    await oasValidator.validateInner(openApiObject, {});
+    await oasValidator.validateInner(openApiObject, config.oasValidatorOptions || {});
   } catch (err) {
     throw new Error('Invalid Openapi document');
   }


### PR DESCRIPTION
Summary:

Some projects use the `anchors` in the openapi.yaml, however, due to https://github.com/Mermade/oas-kit/issues/217, it's disabled by default. The configuration is hardcoded to `{}`, we need to make it configurable, so users can config by themselves. 

Example usage:

```js
    await oas({
        endpoint: '/openapi.json',
        file: path.resolve(process.cwd(), 'openapi.yaml'),
        uiEndpoint: '/',
        oasValidatorOptions: {
            // allow anchors in the openapi.yaml
            anchors: true,
        }
    })
```