### PR TITLE
Update validatePaths type

### DIFF
--- a/.changeset/nice-walls-train.md
+++ b/.changeset/nice-walls-train.md
@@ -1,0 +1,5 @@
+---
+"koa-oas3": minor
+---
+
+update validatePaths type to accept string array or regex array

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -424,3 +424,67 @@ describe('Koa Oas3 with ChowOptions', () => {
   });
 
 })
+
+describe('Pass Regex Array as a validatePaths option', () => {
+  let mw: koa.Middleware;
+  const pathParam = 345;
+
+  beforeEach(async () => {
+    mw = await oas({
+      file: path.resolve('./__tests__/fixtures/pet-store.json'),
+      endpoint: '/openapi',
+      uiEndpoint: '/openapi.html',
+      validatePaths: [new RegExp(`pets(?!/${pathParam})`)],
+      validationOptions: { requestBodyAjvOptions: { allErrors: true } } as ChowOptions
+    });
+  })
+
+  test('should NOT validate paths specified that do not validate agaiinst the RegEx pattern', async () => {
+    const ctx = createContext({
+      url: `/pets/${pathParam}`,
+      headers: {
+        'accept': 'application/json'
+      },
+      method: 'GET'
+    });
+
+    mw = await oas({
+      file: path.resolve('./__tests__/fixtures/pet-store.json'),
+      endpoint: '/openapi',
+      uiEndpoint: '/openapi.html',
+      validatePaths: [new RegExp(`pets(?!/${pathParam})`)],
+      validationOptions: { requestBodyAjvOptions: { allErrors: true } } as ChowOptions
+    });
+
+    const next = jest.fn();
+    await mw(ctx, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  })
+
+  test('should validate paths specified in RegEx pattern', async () => {
+    const ctx = createContext({
+      url: `/pets/`,
+      headers: {
+        'accept': 'application/json'
+      },
+      method: 'GET'
+    });
+
+    mw = await oas({
+      file: path.resolve('./__tests__/fixtures/pet-store.json'),
+      endpoint: '/openapi',
+      uiEndpoint: '/openapi.html',
+      validatePaths: [new RegExp(`pets(?!/${pathParam})`)],
+      validationOptions: { requestBodyAjvOptions: { allErrors: true } } as ChowOptions
+    });
+
+    const next = jest.fn();
+    await mw(ctx, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).not.toHaveBeenCalledWith();
+  })
+
+})

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -439,7 +439,7 @@ describe('Pass Regex Array as a validatePaths option', () => {
     });
   })
 
-  test('should NOT validate paths specified that do not validate agaiinst the RegEx pattern', async () => {
+  test('should NOT validate paths specified that do not validate against the RegExp pattern', async () => {
     const ctx = createContext({
       url: `/pets/${pathParam}`,
       headers: {
@@ -463,7 +463,7 @@ describe('Pass Regex Array as a validatePaths option', () => {
     expect(next).toHaveBeenCalledWith();
   })
 
-  test('should validate paths specified in RegEx pattern', async () => {
+  test('should validate paths specified in RegExp pattern', async () => {
     const ctx = createContext({
       url: `/pets/`,
       headers: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,7 +34,7 @@ export interface Config {
    * Whitelist paths for request validation
    * default: ['/']
    */
-  validatePaths: string[];
+   validatePaths: Array<string> | Array<RegExp>;
   /**
    * Optional base path to swagger ui bundle
    */
@@ -109,7 +109,7 @@ export function validateConfig(cfg: Partial<Config>): Config {
         },
         enableTypes: ['form']
       })
-    },
+    } as any,
     validationOptions: cfg.validationOptions,
     oasValidatorOptions: cfg.oasValidatorOptions
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -109,7 +109,7 @@ export function validateConfig(cfg: Partial<Config>): Config {
         },
         enableTypes: ['form']
       })
-    } as any,
+    },
     validationOptions: cfg.validationOptions,
     oasValidatorOptions: cfg.oasValidatorOptions
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,7 +34,7 @@ export interface Config {
    * Whitelist paths for request validation
    * default: ['/']
    */
-   validatePaths: Array<string> | Array<RegExp>;
+  validatePaths: Array<string> | Array<RegExp>;
   /**
    * Optional base path to swagger ui bundle
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ export async function oas(cfg: Partial<Config>): Promise<koa.Middleware> {
       return;
     }
 
-    if (!config.validatePaths.some(path => ctx.path.startsWith(path))) {
+    if (skipValidation(config.validatePaths, ctx)) {
       // Skip validation if no path matches
       return next();
     }
@@ -150,4 +150,19 @@ async function compileOas(config: Config) {
     compiled: new ChowChow(openApiObject, config.validationOptions),
     doc: openApiObject,
   };
+}
+
+function skipValidation(validatePaths: Array<string> | Array<RegExp>, ctx: koa.Context) {
+  let dontValidate = !validatePaths.some((path: string | RegExp) => {
+    if (isRegexPattern(path)) {
+      return (path as RegExp).test(ctx.path);
+    } else {
+      return ctx.path.startsWith(path as string);
+    }
+  });
+  return dontValidate;
+}
+
+function isRegexPattern(path: string | RegExp) {
+  return typeof path == 'object' ? true : false;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,15 +154,11 @@ async function compileOas(config: Config) {
 
 function skipValidation(validatePaths: Array<string> | Array<RegExp>, ctx: koa.Context) {
   let dontValidate = !validatePaths.some((path: string | RegExp) => {
-    if (isRegexPattern(path)) {
-      return (path as RegExp).test(ctx.path);
+    if (path instanceof RegExp) {
+      return path.test(ctx.path);
     } else {
       return ctx.path.startsWith(path as string);
     }
   });
   return dontValidate;
-}
-
-function isRegexPattern(path: string | RegExp) {
-  return typeof path == 'object' ? true : false;
 }


### PR DESCRIPTION
By adding type `Array<RegExp>` in addition to `Array<string>`, the `validatePaths` parameter can now be used to validate a more specific set of paths.

For example:
Using the regex pattern: `/pets(?!/123)` would allow for paths that start with `/pets` but would _not_ allow the full path `pets/123`.