### PR TITLE
Upgrades oas3-chow-chow version to new major version 4.0.0

### DIFF
--- a/.changeset/sharp-dots-jam.md
+++ b/.changeset/sharp-dots-jam.md
@@ -1,0 +1,5 @@
+---
+"koa-oas3": minor
+---
+
+Upgrade major version of dependency oas3-chow-chow which removes support for node 16 and adds support for node 20 and 22 of oas3-chow-chow and reduces warning logging

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "koa-bodyparser": "^4.2.1",
     "koa-compose": "^4.1.0",
     "oas-validator": "^5.0.3",
-    "oas3-chow-chow": "^3.0.0",
+    "oas3-chow-chow": "^4.0.0",
     "qs": "^6.9.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4109,10 +4109,10 @@ oas-validator@^5.0.3, oas-validator@^5.0.8:
     should "^13.2.1"
     yaml "^1.10.0"
 
-oas3-chow-chow@^3.0.0:
-  version "3.0.0"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/oas3-chow-chow/-/oas3-chow-chow-3.0.0.tgz#9664b979b58b739386e1121f10c57ec17dfbbbc1"
-  integrity sha512-uDVfQ/oJPTVTv7hS0YGN6nt9gc9Cdxi9U7ABcWkjfq6W3580Clj0aTqibuaeA/FwZgy2mmmZy4FjQcMbsRIg1g==
+oas3-chow-chow@^4.0.0:
+  version "4.0.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/oas3-chow-chow/-/oas3-chow-chow-4.0.0.tgz#e88cda2a4f5e2d030f70b5a11204f0372a3d3d5c"
+  integrity sha512-ej/D9qv1Ew9M5l9LruiIAXkCGDOa7+MQeJlL0Xmq4EMEUpscFETixZf26cBjaRVnn3MgGj+QhVUwooHWZFWcjQ==
   dependencies:
     "@apidevtools/json-schema-ref-parser" "^11.1.0"
     ajv "^8.12.0"


### PR DESCRIPTION
As per title, upgrades the oas3-chow-chow version to include two new changes:
- Support for newer node versions (20, 22) and no more support for node 16
- Removing the example keyword from the AJV warning logs